### PR TITLE
Found a way to kill LAMMPS automatically when killing the Python process

### DIFF
--- a/examples/slurm_cpu.py
+++ b/examples/slurm_cpu.py
@@ -1,0 +1,8 @@
+from lammps_simulator import Simulator
+from lammps_simulator.computer import SlurmCPU
+
+computer = SlurmCPU(1, lmp_exec="lmp")
+
+sim = Simulator(directory="simulation")
+sim.set_input_script("in.lammps", temp=300)
+sim.run(computer=computer)

--- a/lammps_simulator/__init__.py
+++ b/lammps_simulator/__init__.py
@@ -1,6 +1,21 @@
 import os
+import sys
+import signal
 import shutil
+#import psutil
 import subprocess
+
+
+def kill_lammps(pid):
+    def signal_handler(sig, frame):    
+        #p = psutil.Process(pid)
+        #p.terminate()
+        os.kill(pid, signal.SIGTERM)
+        raise KeyboardInterrupt
+    
+    signal.signal(signal.SIGINT, signal_handler)
+
+    
 
 
 class Simulator:
@@ -77,6 +92,8 @@ class Simulator:
         main_path = os.getcwd()
         os.chdir(self.wd)
         job_id = computer(self.lmp_script, self.var, stdout, stderr)
+        if computer.slurm == False:
+            kill_lammps(job_id)
         os.chdir(main_path)
         return job_id
 
@@ -95,5 +112,7 @@ class Simulator:
         main_path = os.getcwd()
         os.chdir(self.wd)
         job_id = computer(self.lmp_script, self.var, stdout, stderr)
+        if computer.slurm == False:
+            kill_lammps(job_id)
         os.chdir(main_path)
         return job_id


### PR DESCRIPTION
Added a way to kill the LAMMPS processes when terminating Python. Still needs to be tested and evaluated. Maybe it would be more naturally to do this directly on the computer object?