### PR TITLE
Added support for slurm arguments without setting (e.g. --wait)

### DIFF
--- a/lammps_simulator/computer.py
+++ b/lammps_simulator/computer.py
@@ -80,7 +80,10 @@ class Computer:
         with open(jobscript, "w") as f:
             f.write("#!/bin/bash\n\n")
             for key, setting in slurm_args.items():
-                f.write(f"#SBATCH --{key}={setting}\n#\n")
+                if setting is None:
+                    f.write(f"#SBATCH --{key}\n#\n")
+                else:
+                    f.write(f"#SBATCH --{key}={setting}\n#\n")
             f.write("\n")
             f.write(" ".join(exec_list))
 


### PR DESCRIPTION
Added support for slurm arguments which does not require an argument (e.g. --wait). Simply pass None as the value for a key. E.g. `slurm_args['wait'] = None` will result in `#SBATCH --wait` in the job script.