### PR TITLE
Pre-generating and adding to jobscript before running/submitting to ssh

### DIFF
--- a/lammps_simulator/.vscode/settings.json
+++ b/lammps_simulator/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#b7dfce",
+        "activityBar.background": "#b7dfce",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#a57bc4",
+        "activityBarBadge.foreground": "#15202b",
+        "commandCenter.border": "#15202b99",
+        "sash.hoverBorder": "#b7dfce",
+        "statusBar.background": "#93d0b6",
+        "statusBar.foreground": "#15202b",
+        "statusBarItem.hoverBackground": "#6fc19e",
+        "statusBarItem.remoteBackground": "#93d0b6",
+        "statusBarItem.remoteForeground": "#15202b",
+        "titleBar.activeBackground": "#93d0b6",
+        "titleBar.activeForeground": "#15202b",
+        "titleBar.inactiveBackground": "#93d0b699",
+        "titleBar.inactiveForeground": "#15202b99"
+    },
+    "peacock.color": "#93d0b6"
+}

--- a/lammps_simulator/device.py
+++ b/lammps_simulator/device.py
@@ -158,7 +158,7 @@ class Device:
  
 
     @staticmethod
-    def gen_jobscript_string(exec_list, slurm_args):  
+    def gen_jobscript_string(exec_list, slurm_args, linebreak = True):  
         """Generate jobscript string:
 
             #!/bin/bash
@@ -181,7 +181,8 @@ class Device:
                 string += f"#SBATCH --{key}={setting}\n#\n"
         string += "\n"
         string += " ".join(exec_list)
-        string += "\n"
+        if linebreak:
+            string += "\n"
         return string
         
 

--- a/lammps_simulator/device.py
+++ b/lammps_simulator/device.py
@@ -120,8 +120,7 @@ class Device:
         # Might find better name but used 'write_jobscript' for bool value
         with open(path, "w") as f:
             f.write(string)
-        
-                
+             
 
     @staticmethod
     def get_exec_list(num_procs, lmp_exec, lmp_args, lmp_var):

--- a/lammps_simulator/device.py
+++ b/lammps_simulator/device.py
@@ -9,25 +9,25 @@ class Device:
 
         mpirun -n {num_procs} {lmp_exec} {lmp_script}
 
-    :param num_procs: number of processes, 1 by default
+    :param num_procs: number of processes, 1 by default.
     :type num_procs: int
-    :param lmp_exec: LAMMPS executable, 'lmp' by default
+    :param lmp_exec: LAMMPS executable, 'lmp' by default.
     :type lmp_exec: str
-    :param lmp_args: LAMMPS command line arguments
+    :param lmp_args: LAMMPS command line arguments.
     :type lmp_args: dict
-    :param slurm: whether or not simulation should be run from Slurm, 'False' by default
+    :param slurm: whether or not simulation should be run from Slurm, 'False' by default.
     :type slurm: bool
-    :param slurm_args: slurm sbatch command line arguments
+    :param slurm_args: slurm sbatch command line arguments.
     :type slurm_args: dict
-    :param write_jobscript: whether or not to write jobscript, 'True by default'
+    :param write_jobscript: whether or not to write jobscript, 'True by default'.
     :type write_jobscript: bool
-    :param jopscript_name: filename of jobscript, 'job.sh' by default
+    :param jopscript_name: filename of jobscript, 'job.sh' by default.
     :type jobscript: str
-    :param jobscript_string: container for jobscript text, 'None' by default  
-    :type string / NoneType
-    :param dir: working directory including any ssh path, 'None' by default (must be updated)
-    :type string / NoneType
-    :param execute: whether or not to run the program, 'True' by default
+    :param jobscript_string: container for jobscript text, 'None' by default.
+    :type str / NoneType
+    :param dir: working directory including any ssh path, 'None' by default (must be updated).
+    :type str / NoneType
+    :param execute: whether or not to run the program, 'True' by default.
     :type bool
     """
     def __init__(self, num_procs=1, lmp_exec="lmp", lmp_args={}, slurm=False,
@@ -111,51 +111,13 @@ class Device:
         
         
         
-        
-        
-        
-        # self.lmp_args["-in"] = lmp_script
-        # exec_list = self.get_exec_list(self.num_procs, self.lmp_exec, self.lmp_args, lmp_var)
-       
-        # if self.generate_jobscript:
-        #     if self.ssh_dir is None: # locally stored
-        #         self.gen_jobscript(exec_list, self.jobscript, self.slurm_args)
-        #     else: # temporary locally stored
-        #         self.gen_jobscript(exec_list, self.sendlabel + self.jobscript, self.slurm_args)
-            
-        # if not self.run: # Opportunity to just generate jobscript
-        #     return 0
-        
-        # if self.slurm: # Run with slurm
-        #     if self.ssh_dir is None: # Run locally
-        #         output = subprocess.check_output(["sbatch", self.jobscript])
-        #     else: # Run on ssh 
-        #         subprocess.run(['rsync', '-av', '--remove-source-files', self.sendlabel + self.jobscript, self.ssh_dir + self.jobscript]) 
-        #         ssh, wd = self.ssh_dir.split(':')
-        #         output = subprocess.check_output(["ssh", ssh, f"cd {wd} && sbatch {self.jobscript}"])
-        #     job_id = int(re.findall("([0-9]+)", str(output))[0])
-        #     print(f"Job submitted with job ID {job_id}")
-        #     return job_id
-         
-        # else: # Run directly 
-        #     if self.ssh_dir is None: 
-        #         procs = subprocess.Popen(exec_list, stdout=stdout, stderr=stderr)
-        #     else:
-        #         ssh, wd = self.ssh_dir.split(':')
-        #         procs = subprocess.Popen(["ssh", ssh, f"cd {wd} && {' '.join(exec_list)}"], stdout=stdout, stderr=stderr)
-        #     pid = procs.pid
-        #     print(f"Simulation started with process ID {pid}")
-        #     return pid
-
  
     @staticmethod
     def store_jobscript(string, path): 
-        # Might find better name but used write_jobscript
-        # for bool value
+        # Might find better name but used write_jobscript for bool value
         with open(path, "w") as f:
             f.write(string)
         
-            
                 
 
     @staticmethod
@@ -193,7 +155,7 @@ class Device:
 
     @staticmethod
     def gen_jobscript_string(exec_list, slurm_args): # TODO: Update docstring 
-        """Generate jobscript:
+        """Generate jobscript string:
 
             #!/bin/bash
             #SBATCH --{key1}={value1}

--- a/lammps_simulator/device.py
+++ b/lammps_simulator/device.py
@@ -1,7 +1,8 @@
 import re
 import subprocess
 from numpy import ndarray
-import os # Consider changing back in simulator as before
+import os 
+import warnings
 
 
 class Device:
@@ -41,14 +42,18 @@ class Device:
         self.slurm_args = slurm_args
         self.write_jobscript = write_jobscript
         self.jobscript_name = jobscript_name 
-        self.jobscript_string = jobscript_string # Change to jobscript XXX
+        self.jobscript_string = jobscript_string 
         self.execute = execute
         
-        if (":" in dir):
-            self.ssh, self.wd = dir.split(":")
+        if dir is not None:
+            if (":" in dir):
+                self.ssh, self.wd = dir.split(":")
+            else:
+                self.ssh = None
+                self.wd = dir
         else:
-            self.ssh = None
-            self.wd = dir
+            warnings.warn("Working directory is not defined!")
+           
 
 
     def __str__(self):
@@ -82,7 +87,6 @@ class Device:
                 p.communicate(input=str.encode(self.jobscript_string))
 
         if not self.execute: # Option to only generate jobscript
-            print("Simulation run finished with \'execute = False\'")
             return 0
         
         if self.slurm: # Run with slurm
@@ -98,7 +102,6 @@ class Device:
       
         else: # Run directly 
             if self.ssh is None: 
-                print(exec_list)
                 main_path = os.getcwd()
                 os.chdir(self.wd)
                 procs = subprocess.Popen(exec_list, stdout=stdout, stderr=stderr)
@@ -114,7 +117,7 @@ class Device:
  
     @staticmethod
     def store_jobscript(string, path): 
-        # Might find better name but used write_jobscript for bool value
+        # Might find better name but used 'write_jobscript' for bool value
         with open(path, "w") as f:
             f.write(string)
         
@@ -138,6 +141,7 @@ class Device:
         :returns: list with mpirun executables
         :rtype: list of str
         """
+       
         exec_list = ["mpirun", "-n", str(num_procs), lmp_exec]
         for key, value in lmp_args.items():
             exec_list.append(key)
@@ -154,7 +158,7 @@ class Device:
  
 
     @staticmethod
-    def gen_jobscript_string(exec_list, slurm_args): # TODO: Update docstring 
+    def gen_jobscript_string(exec_list, slurm_args):  
         """Generate jobscript string:
 
             #!/bin/bash

--- a/lammps_simulator/simulator.py
+++ b/lammps_simulator/simulator.py
@@ -16,11 +16,8 @@ class Simulator:
     from .device import Device
 
     def __init__(self, directory=None, overwrite=False):
-        
         self.jobscript_string = None # Option to store jobscript in simulator class
-        self.sim_settings = {'dir': directory} # find better name
-        
-        # self.run = None
+        self.sim_settings = {'dir': directory} 
         
         if directory is None:
             self.wd = None
@@ -187,9 +184,6 @@ class Simulator:
         self.jobscript_string = self.Device.gen_jobscript_string(exec_list, self.sim_settings['slurm_args'])
      
    
-        
-
-
     def add_to_jobscript(self, string, linebreak = True):
         """ Add a string to already exisitng self.jobscript_string.
         
@@ -203,8 +197,6 @@ class Simulator:
         if linebreak: 
             self.jobscript_string += "\n"
       
-
-
 
     def run_custom(self, stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE, **kwargs):

--- a/lammps_simulator/simulator.py
+++ b/lammps_simulator/simulator.py
@@ -146,6 +146,9 @@ class Simulator:
             device = computer
              
         job_id = device(self.lmp_script, self.var, stdout, stderr)
+        if job_id == 0 & kwargs['execute'] == False:
+            print("Simulation.run() finished with \'execute = False\'")
+            
         return job_id
     
     def set_run_settings(self, **kwargs):

--- a/lammps_simulator/simulator.py
+++ b/lammps_simulator/simulator.py
@@ -18,7 +18,7 @@ class Simulator:
     def __init__(self, directory=None, overwrite=False):
         
         self.jobscript_string = None # Option to store jobscript in simulator class
-        self.my_settings = {'dir': directory} # find better name
+        self.sim_settings = {'dir': directory} # find better name
         
         # self.run = None
         
@@ -140,7 +140,7 @@ class Simulator:
         self.set_run_settings(**kwargs)
         self.set_run_settings(jobscript_string = self.jobscript_string)
         if computer is None and device is None:
-            device = self.Device(**self.my_settings)
+            device = self.Device(**self.sim_settings)
         elif device is None:
             warnings.warn("'Computer' is deprecated from version 1.1.0 and is replaced by the more intuitive 'Device'", DeprecationWarning)
             device = computer
@@ -149,28 +149,49 @@ class Simulator:
         return job_id
     
     def set_run_settings(self, **kwargs):
+        """ Update class dict: self.sim_settings with kwargs
+            already existing keys get overwitten by kwargs 
+            but generates a warning.                            
+            
+        :param kwargs: arguments to be added to self.sim_settings.
+        :type kwargs: unpacked dictionary
+        """ 
         # Update dict: Merge where kwargs overwrites
-        old_dict = self.my_settings
-        self.my_settings = self.my_settings | kwargs 
+        old_dict = self.sim_settings
+        self.sim_settings = self.sim_settings | kwargs 
         for key in old_dict:
-            if not old_dict[key] == self.my_settings[key]:
-                print(f'WARNING: \'{key}\' got updated from {old_dict[key]} to {self.my_settings[key]} and might not match any pregeneraterd jobscripts.')
+            if not old_dict[key] == self.sim_settings[key]:
+                print(f'WARNING: \'{key}\' got updated from {old_dict[key]} to {self.sim_settings[key]} and might not match any pregeneraterd jobscripts.')
 
 
    
     def pre_generate_jobscript(self, **kwargs):
+        """ Pre-generate jobscript string from available information
+            from self.sim_settings and kwargs.
+            
+        :param kwargs: arguments to be added to self.sim_settings before generating jobscript string.
+        :type kwargs: unpacked dictionary 
+        """
+            
         self.set_run_settings(**kwargs)
-        self.my_settings = {'lmp_args': {}} | self.my_settings
-        self.my_settings['lmp_args']['-in'] = self.lmp_script
+        self.sim_settings = {'lmp_args': {}} | self.sim_settings
+        self.sim_settings['lmp_args']['-in'] = self.lmp_script
         
-        exec_list = self.Device.get_exec_list(self.my_settings['num_procs'] , self.my_settings['lmp_exec'], self.my_settings['lmp_args'], self.var)
-        self.jobscript_string = self.Device.gen_jobscript_string(exec_list, self.my_settings['slurm_args'])
+        exec_list = self.Device.get_exec_list(self.sim_settings['num_procs'] , self.sim_settings['lmp_exec'], self.sim_settings['lmp_args'], self.var)
+        self.jobscript_string = self.Device.gen_jobscript_string(exec_list, self.sim_settings['slurm_args'])
      
    
         
 
 
     def add_to_jobscript(self, string, linebreak = True):
+        """ Add a string to already exisitng self.jobscript_string.
+        
+        :param string: String to be added to self.jobscript_string
+        :type string: str
+        :param linebreak: whether or not to add linebreak after string, 'True' by default. 
+        :type linebreak: bool
+        """ 
         assert(isinstance(self.jobscript_string, str)), "Cannot add to jobscript when not initialized"
         self.jobscript_string += string
         if linebreak: 

--- a/lammps_simulator/simulator.py
+++ b/lammps_simulator/simulator.py
@@ -145,10 +145,13 @@ class Simulator:
             warnings.warn("'Computer' is deprecated from version 1.1.0 and is replaced by the more intuitive 'Device'", DeprecationWarning)
             device = computer
              
-        job_id = device(self.lmp_script, self.var, stdout, stderr)
-        if job_id == 0 & kwargs['execute'] == False:
-            print("Simulation.run() finished with \'execute = False\'")
-            
+        job_id = device(self.lmp_script, self.var, stdout, stderr)   
+        try: 
+            if kwargs['execute'] == False:
+                print("Simulation.run() finished with \'execute = False\'")
+        except KeyError:
+            pass
+        
         return job_id
     
     def set_run_settings(self, **kwargs):


### PR DESCRIPTION
Hei Even, 

Har endret strukturen litt, så det nå er mulig å genere jobscriptet på forhånd og dermed legge til ekstra linjer i jobscriptet før det kjøres eller submittes til ssh. Dette var nyttig for min del der jeg først kjører et script som generer ulike restart filer som da skal startes flere gange med ulike variabler. Dette skal være kompatibelt med tidligere måter å bruke pakken på. Et pseudo eksempel på bruken av den nye funksjonaliteten er visst nedenfor.

```
sim = Simulator(directory = 'egil:folder')
sim.copy_to_wd( 'file1', 'file2')

sim.set_input_script("my_script.in", var1 = my_var1, var2 = my_var2)    
slurm_args = {'job-name':jobname, 'partition':'normal', 'ntasks':16, 'nodes':1}
sim.pre_generate_jobscript(num_procs=16, lmp_exec="lmp", slurm_args = slurm_args)    

sim.add_to_jobscript("\
line 1 \n
line2 \n
line 3 \n ")

sim.run(slurm = True, execute = True) # execute == False -> Only submits job without running it
```